### PR TITLE
:memo: rename 'settings' to 'config'

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -135,7 +135,7 @@ SystemPanda({
             },
         },
     },
-    settings: {
+    config: {
         port: Number(process.env.PORT),
         db: {
             URI: process.env.DATABASE_URL!,


### PR DESCRIPTION
### Description
Update outdated `get-started.md`. The example still used `settings` instead of `config` leading to errors about unable to destructure from something that's undefined.

### Scope of Changes
- renames `settings` to `config`